### PR TITLE
Switch renovate config to extend default config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base"],
+  "extends": [
+    "local>nv-gha-runners/renovate-config",
+    "group:allNonMajor"
+  ],
   "schedule": ["before 4am on the first day of the month"]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,5 @@
   "extends": [
     "local>nv-gha-runners/renovate-config",
     "group:allNonMajor"
-  ],
-  "schedule": ["before 4am on the first day of the month"]
+  ]
 }


### PR DESCRIPTION
I have validated that "extends" works for arc-nvks-argocd. Apply the same change to this repo to have consistent renovate behavior.